### PR TITLE
Fix EOFError

### DIFF
--- a/config/chat_data.py
+++ b/config/chat_data.py
@@ -2,16 +2,23 @@ import atexit
 import os
 import pickle
 
-if os.path.exists('data.pkl'):
-    with open('data.pkl', 'rb') as file:
-        chat_data = pickle.load(file)
+file_path = 'data.pkl'
+
+# 检查文件是否存在并且不为空
+if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
+    try:
+        with open(file_path, 'rb') as file:
+            chat_data = pickle.load(file)
+    except (EOFError, pickle.UnpicklingError):
+        # 处理读取错误，初始化为空字典
+        chat_data = {}
+        print("Failed to load data.pkl, initializing with empty data.")
 else:
     chat_data = {}
 
-
 def save_data():
-    with open('data.pkl', 'wb') as f:
+    with open(file_path, 'wb') as f:
         pickle.dump(chat_data, f)
 
-
+# 在程序退出时保存数据
 atexit.register(save_data)


### PR DESCRIPTION
Fix EOFError: Ran out of input

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an EOFError by ensuring 'data.pkl' exists and is not empty before loading. It also adds error handling to initialize chat data as an empty dictionary if loading fails.

- **Bug Fixes**:
    - Fixed EOFError by adding a check for file existence and non-emptiness before attempting to load data from 'data.pkl'.
- **Enhancements**:
    - Added error handling for EOFError and pickle.UnpicklingError to initialize chat data as an empty dictionary if loading fails.

<!-- Generated by sourcery-ai[bot]: end summary -->